### PR TITLE
Updated broken Judging Criteria link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Contestants are given shares for bugs discovered based on severity, and those sh
 
 Each share is redeemable for: `pot / number of shares`
 
-**Important mechanism update:** For contests starting on or after February 3, 2022, low and non-critical findings should be submitted as a SINGLE QA report; contests will allocate a fixed 10% of prize pools toward QA reports. (Similarly, gas findings should be submitted as a single gas report.) For more on QA and gas reports, see [Judging criteria](roles/wardens/judging-criteria).
+**Important mechanism update:** For contests starting on or after February 3, 2022, low and non-critical findings should be submitted as a SINGLE QA report; contests will allocate a fixed 10% of prize pools toward QA reports. (Similarly, gas findings should be submitted as a single gas report.) For more on QA and gas reports, see [Judging criteria](https://docs.code4rena.com/roles/wardens/judging-criteria).
 
 **Judges** are incentivized to review findings and determine allocation of the prize pool by receiving a share of the prize pool themselves.


### PR DESCRIPTION
The github relative link doesn't seem to be working on the C4 website which leads to a 404 error. Basically "_(roles/wardens/judging-criteria)_" is turning into "_https://github.com/code-423n4/docs/blob/main/roles/wardens/judging-criteria/README.md_" when clicking from the C4 website, which causes the error.

Updated to absolute link instead: https://docs.code4rena.com/roles/wardens/judging-criteria

(Note: This PR related to issue #12)