### PR TITLE
Clarify guidelines and judging criteria for Analyses

### DIFF
--- a/awarding/incentive-model-and-awards/README.md
+++ b/awarding/incentive-model-and-awards/README.md
@@ -68,6 +68,8 @@ Historically, Code4rena valued non-critical findings at 0; the intent of the QA 
 
 **Note:** Audits pre-dating February 3, 2022 awarded low risk and gas optimization shares as: `Low Risk Shares: 1 * (0.9 ^ (findingCount - 1)) / findingCount`
 
+In the unlikely event that zero high- or medium-risk vulnerabilities are found, the HM award pool will be divided based on the QA Report curve.
+
 ## Grades for Analyses, QA and Gas reports
 
 Analyses, QA reports and Gas reports are graded A, B, or C.

--- a/awarding/judging-criteria/README.md
+++ b/awarding/judging-criteria/README.md
@@ -1,6 +1,6 @@
 # Judging criteria
 
-### Submission Review Process
+## Submission Review Process
 
 C4 strives to ensure a deliberate and transparent process for reviewing and judging submissions.
 
@@ -8,15 +8,15 @@ At the end of a given audit period, all reports will be reviewed and categorized
 
 Reports are also judged based on grammar, conciseness, and formatting.
 
-### Best Current Practices
+## Best Current Practices
 
 The [Code4rena org repo](https://github.com/code-423n4/org) documents open discussions and emergent best practices for judging C4 audits. Judges are encouraged to review [open issues in that repo](https://github.com/code-423n4/org/issues) regularly.
 
-### Duplicate Submissions
+## Duplicate Submissions
 
 Should multiple submissions describing the same vulnerability be submitted, Judges have the discretion to place these bugs into the same bucket, in which case, the award will be shared among those who submitted. However, multiple submissions from the same warden (or warden team), are treated as one by the awarding algorithm and do not split the pie into smaller pieces.
 
-### Scope
+## Scope
 
 Each audit may include code that is explicitly in scope and out of scope, and specific issues which also may be identified as out of scope.
 
@@ -26,7 +26,7 @@ Wardens _may_ elect to argue to bring things into scope—either by making the c
 
 In the interest of everyone's time, **please do not offer QA or gas reports on any code or known issues which are identified as out of scope.**
 
-### Scoring
+## Scoring
 
 The scoring system has three primary goals:
 
@@ -35,6 +35,8 @@ The scoring system has three primary goals:
 * Encouraging coordination by incentivizing Wardens to form teams.
 
 ### Analysis
+
+Analyses are judged A, B, or C, with C being unsatisfactory and ineligible for awards. The judge selects the best Analysis for inclusion in the audit report.
 
 An analysis is a written submission outlining:
 
@@ -45,26 +47,28 @@ An analysis is a written submission outlining:
 
 If individual findings are trees, Analyses are the forest. They provide wardens with an opportunity to contribute value through high level insights and advice that aren't necessarily covered by specific bugs -- and a way to get credit for doing so.
 
-Analyses are judged A/B/C, with the top Analysis selected for inclusion in the audit report, similarly to Gas and QA reports.
+Each Analysis is judged based on quality and thoroughness as compared with other reports, with awards distributed on a curve. 
 
 ### QA reports (low/non-critical)
 
+QA reports are graded A, B, or C, with C being unsatisfactory and ineligible for awards. The judge selects the best QA report for inclusion in the audit report.
+
 Low and non-critical findings must be submitted as a _single_ QA report per warden. We allocate a **fixed 2.5% of prize pools toward QA reports.**
 
-Your QA report should include:
+QA reports should include:
 
 * all low severity findings; and
 * all non-critical findings.
 
-Each QA report will be assessed based on report quality and thoroughness as compared with other reports, with awards distributed on a curve. The top QA report author will receive the top prize from the category.
+Each QA report should be assessed based on report quality and thoroughness as compared with other reports, with awards distributed on a curve. 
 
-Wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts) will have their scores reduced by judges.
-
-In the unlikely event that zero high- or medium-risk vulnerabilities are found, the full pool will be divided based on the QA Report curve.
+Judges have discretion to assign a lower grade to wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts).
 
 ### Gas reports
 
-Gas reports should be submitted using the **same approach as the QA reports:** a single submission per warden which includes all identified optimizations. The gas pool will be allocated on a curve, and the top reporter will receive the top prize in the category.
+Gas reports are graded A, B, or C, with C being unsatisfactory and ineligible for awards. The judge selects the best Gas report for inclusion in the audit report.
+
+Gas reports should be submitted using the **same approach as the QA reports:** a single submission per warden which includes all identified optimizations. The gas pool is allocated on a curve. 
 
 The gas pool varies from audit to audit, but typically it consists of 2.5% of the total prize pool. The precise gas pool for each audit can be found in that audit's repo.
 

--- a/awarding/judging-criteria/README.md
+++ b/awarding/judging-criteria/README.md
@@ -62,7 +62,7 @@ QA reports should include:
 
 Each QA report should be assessed based on report quality and thoroughness as compared with other reports, with awards distributed on a curve. 
 
-Judges have discretion to assign a lower grade to wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts).
+Judges have discretion to assign a lower grade to wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts). Judges may also raise the severity of a QA finding at their discretion. 
 
 ### Gas reports
 

--- a/roles/wardens/submission-policy.md
+++ b/roles/wardens/submission-policy.md
@@ -151,7 +151,7 @@ Wardens may use automated tools as a first pass, and build on these findings to 
 
 The following methods are not authorized means of testing within C4 code audits:
 
-* Testing exploits on mainnet.
+* Testing exploits on deployed contracts or systems.
 * Network denial of service (DoS or DDoS) tests or other tests that impair access to or damage a system or data.
 * Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
 

--- a/roles/wardens/submission-policy.md
+++ b/roles/wardens/submission-policy.md
@@ -39,13 +39,50 @@ In order to help us triage and prioritize submissions, please ensure that your r
 
 It is also recommended to ensure you receive email confirmation of each submission. (If you do not see an email confirmation, please check your spam folder.)
 
-### Report format
+### Submission types
 
+- **High, Medium, and QA reports:** 
+  - Wardens should [review Code4rena's severity categorization](https://docs.code4rena.com/awarding/judging-criteria/severity-categorization) prior to submitting vulnerabilities, and select the appropriate risk when submitting.
+  - Medium or High severity findings should be submitted individually.
+  - All QA findings (Low risk or Non-critical) must be submitted as a single QA report per warden (or team).
+  - Centralization risks, systemic risks, and architecture recommendations should be submitted as part of an Analysis (see below).
+- **Analyses:** An analysis is a written submission outlining:
+  - Wardens' analysis of the codebase as a whole and any observations or advice they have about architecture, mechanism, or approach
+  - Broader concerns like systemic risks or centralization risks
+  - The approach taken in reviewing the code
+  - New insights and learnings from the audit
+- **Gas optimizations:** All identified gas optimizations should be submitted as a separate report. *Note:* the gas award pool is set according to the sponsor's preference, and some audits do not include gas optimizations awards.
+
+
+### Report formats
 - Medium or High severity findings should be submitted individually.
-- All QA findings (Low risk or Non-critical) must be submitted as a single QA report per warden (or team). 
-- All Gas optimizations must be submitted as a single Gas report per warden (or team).
+- Analyses should be submitted via the "Submit Analysis report" form.
+- All QA findings (Low risk or Non-critical) must be submitted within a single QA report per warden (or team). 
+- All Gas optimizations must be submitted within a single Gas report per warden (or team).
 
 Wardens who submit multiple QA and/or Gas findings to a single audit without following the required format will have all QA/Gas submissions invalidated for that audit. 
+
+### QA reports (low/non-critical)
+
+Low and non-critical findings must be submitted as a _single_ QA report per warden. We allocate a **fixed 2.5% of prize pools toward QA reports.**
+
+Your QA report should include:
+
+* all low severity findings; and
+* all non-critical findings.
+
+Each QA report will be assessed based on report quality and thoroughness as compared with other reports, with awards distributed on a curve. The top QA report author will receive the top prize from the category.
+
+Wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts) will have their scores reduced by judges.
+
+In the unlikely event that zero high- or medium-risk vulnerabilities are found, the full pool will be divided based on the QA Report curve.
+
+### Gas reports
+
+Gas reports should be submitted using the **same approach as the QA reports:** a single submission per warden which includes all identified optimizations. The gas pool will be allocated on a curve, and the top reporter will receive the top prize in the category.
+
+The gas pool varies from audit to audit, but typically it consists of 2.5% of the total prize pool. The precise gas pool for each audit can be found in that audit's repo.
+
 
 For more details on QA and Gas reports, and estimating risk, please see [Judging Criteria](https://docs.code4rena.com/roles/wardens/judging-criteria#qa-reports-low-non-critical).
 
@@ -110,11 +147,19 @@ Judges must make the best decision they can regarding quality and understandabil
 
 Wardens may use automated tools as a first pass, and build on these findings to identify High and Medium severity issues ("HM issues"). However, submissions based on automated tools will have a higher burden of proof for demonstrating to sponsors a relevant HM exploit path in order to be considered satisfactory.
 
+## Unauthorized test methods
+
+The following methods are not authorized means of testing within C4 code audits:
+
+* Testing exploits on mainnet.
+* Network denial of service (DoS or DDoS) tests or other tests that impair access to or damage a system or data.
+* Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
+
 ## Editing a report
 
 To edit a submitted finding in an open audit:
 
-1. Sign into https://code4rena.com with your wallet. 
+1. Sign into your https://code4rena.com user account. 
 2. Find the audit on the C4 Audit page and click “view competition"
 3. Click on the “Findings” tab. There you will see a list of all your submissions for that audit (both individual and team findings).
 4. Select a finding from the list, make your edits and re-submit.
@@ -133,14 +178,6 @@ In this situation, wardens who wish to have a report withdrawn should:
 4. Select a finding from the list, and choose the "withdraw" option.
 
 Submissions must be withdrawn before the audit deadline.
-
-## Unauthorized test methods
-
-The following methods are not authorized means of testing within C4 code audits:
-
-* Testing exploits on mainnet.
-* Network denial of service (DoS or DDoS) tests or other tests that impair access to or damage a system or data.
-* Physical testing (e.g. office access, open doors, tailgating), social engineering (e.g. phishing, vishing), or any other non-technical vulnerability testing.
 
 ## Questions
 


### PR DESCRIPTION
- Update Submission policy, Judging Criteria, and Incentive Model and Awards pages to clarify the guidelines for Analyses
- Update language for other submission types for greater consistency and clarity
- Clarify that centralization risks belong in Analyses