### PR TITLE
Validator and account management updates

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -8,7 +8,7 @@
   * [Submission guidelines](roles/wardens/submission-guidelines.md)
   * [Submission policy](roles/wardens/submission-policy.md)
   * [Solo/team audits](roles/wardens/solo-team-audits.md)
-  * [Set up your warden account](roles/wardens/warden-auth.md)
+  * [Set up your warden account](structure/account-management.md)
   * [Tools and resources](roles/wardens/tools-and-resources.md)
 * [Sponsors](roles/sponsors/README.md)
   * [Audit process](roles/sponsors/contest-process.md)
@@ -42,6 +42,7 @@
 
 ## Other Details <a href="#structure" id="structure"></a>
 
+* [Account setup and management](structure/account-management.md)
 * [FAQ](structure/frequently-asked-questions.md)
 * [Audit timeline](structure/our-process/README.md)
 * [Where can I find…?](structure/where-can-i-find....md)

--- a/roles/certified-contributors/sr-backstage-wardens.md
+++ b/roles/certified-contributors/sr-backstage-wardens.md
@@ -16,6 +16,8 @@ The minimum criteria to become a Certified SR are as follows:
 
 Once you meet the eligibility criteria, submit a [Help Desk Request](https://code4rena.com/help/) to request the SR role, and C4 staff will get you set up.
 
+You should also verify your Github account via your Code4rena account management screen, in order to access private repos.
+
 ## Certified contributor professional conduct guidelines
 
 Contributors may lose their SR role by violating the code of professional conduct as outlined in the certified contributor agreement. This code asks wardens to:

--- a/roles/certified-contributors/sr-backstage-wardens.md
+++ b/roles/certified-contributors/sr-backstage-wardens.md
@@ -16,7 +16,7 @@ The minimum criteria to become a Certified SR are as follows:
 
 Once you meet the eligibility criteria, submit a [Help Desk Request](https://code4rena.com/help/) to request the SR role, and C4 staff will get you set up.
 
-You should also verify your Github account via your Code4rena account management screen, in order to access private repos.
+You should also verify your Github account via [your Code4rena account management screen](https://code4rena.com/account), in order to access private repos.
 
 ## Certified contributor professional conduct guidelines
 

--- a/roles/certified-contributors/validators.md
+++ b/roles/certified-contributors/validators.md
@@ -1,6 +1,6 @@
 # Validator role
 
-> Validators decentralize triage by reviewing submissions from wardens with accuracy rates below the qualifying threshold (eg 50%).
+> Validators triage submissions from wardens with accuracy rates below the qualifying threshold; they also de-dupe all submissions.
 > 
 
 All open competitive audits at Code4rena that begin on or after April 30, 2024 will include Validators.
@@ -9,14 +9,15 @@ All open competitive audits at Code4rena that begin on or after April 30, 2024 w
 
 - Each competition has a **qualifying threshold** that allows wardens to bypass validators. This threshold is based on your submission accuracy rate, as well as being established as a quality contributor and as non-sybil. (For those familiar with ‘backstage warden’ criteria, it is essentially that plus an acceptable accuracy rate.)
 - Qualified wardens’ submissions go directly to the usual findings repo.
+- Any assigned Pro League wardens' submissions go directly to the findings repo.
 - All other wardens’ submissions are routed to a Validation repo.
-- 3-5 **Validators** review submissions in the Validation repo immediately after the audit closes
+- **Validators** review submissions in the Validation repo immediately after the audit closes
     - Satisfactory submissions are forwarded to the findings repo
     - Unsatisfactory submissions are closed
-    - Validators may also enhance submissions (add PoC, increase quality of report, etc.) in exchange for a percentage of the finding’s payout. (See “Awarding” section below.)
+    - ~~Validators may also enhance submissions (add PoC, increase quality of report, etc.) in exchange for a percentage of the finding’s payout. (See “Awarding” section below.)~~ (Validator enhancements are paused until further notice.)
 - The judge reviews all submissions in the findings repo.
 
-The new **Validator** role replaces the Lookout role, so the Lookout pool will be distributed to Validators instead; Validators can earn additional awards by enhancing submissions they review. More details on compensation follow below. 
+The **Validator** role replaces the Lookout role.
 
 ## Whose submissions require Validator review?
 
@@ -28,97 +29,28 @@ The new **Validator** role replaces the Lookout role, so the Lookout pool will b
 
 ## Validation Round (for RSVP’d Validators) — first 48 hours
 
-- 3-5 Validators are selected for each audit, via RSVP in #rsvp-judging
-- Validators who participate in the audit will be automatically assigned a first batch of 5 issues
-- Each Validator can label an issue as `sufficient quality`, `insufficient quality` , `unknown`, or `improved`
+- A Validator is selected for each audit, via RSVP in #rsvp-judging
+- The Validator can label an issue as `sufficient quality` or `insufficient quality` 
     - `sufficient quality` - issue is valid; forwards submission to the findings repo
     - `insufficient quality` - closes issue and does not forward
-    - `unknown` - returns issue to the Validator pool
-    - `improved` - Validator enhanced issue; forwards submission to the findings repo
-- Validator can edit (improve) an issue and submit it (see below for more detail)
-- After completing 5 issues, another set of 5 will be assigned to you.
-- Reviewing 1 submission (adding any label other than `unknown`) from within the `unknown` queue will assign you another 5 issues. This incentivizes picking up issues that other validators passed on in order to capture more of the pool since you can only have a limited number of issues assigned to you at a given time.
-- In addition to the initial set of 5 HM issues, each Validator is assigned a share of QA and Gas reports to review: `total_reports / total_validators`
-    - Each validator should forward all satisfactory QA/Gas reports to the findings repo for judging.
+- The Validator de-dupes all `sufficient quality` High- and Medium-risk submissions by selecting a `primary` and grouping duplicates with that primary finding. 
+    - The Judge is responsible for reviewing and finalizing dupe sets, and assessing quality.
+- All satisfactory submissions are forwarded to the findings repo for judging.
+    - Validators' decisions are batch-processed via .csv file upload in the validation repo
+    - The .csv processing tool is called `howlbot`
 - ⏰ **Timeline:** goal is for Validators to complete work within 48h after the audit closes.
-
-## Limbo Round (for any Judges/Validators) — after 48 hours
-
-After 48 hours, any issues in the validation repo that have not yet been reviewed are in “Limbo” and available for ***any* judge or lookout(`*`)** to review. 
-
-Once the audit is finalized: 
-
-- Validators are awarded for each validation.
-- Validators’ awards are reduced for:
-    - incorrect validations
-    - “passing” on assigned submissions (labeling as `unknown`)
-
-Each round's validations have different values.
-
-(`*`) Note: After April 30, 2024, the Lookout role will be retired in favour of the new Validator role. All current judges and lookouts will be granted the Validator role by default. Going forward, the Validator role will be granted to community members who meet the eligibility criteria. 
 
 ---
 
-## De-duping
-
-- Submissions in the validator repo will have C4’s AI deduper run on them
-    - Each dupe set is assigned to a single Validator
-    - Within each dupe set, the Validator chooses from the following paths:
-        1. If high quality, valid submissions are present that do not need editing → forward *these submissions only* to the findings repo; all other dupes are discarded. 
-        2. If condition (1) is not met, Validator selects 1-3 best submissions within the dupe set. Any edits/enhancements are applied to the entire set. 
-            
-            N.B. In such cases, the judge should review edit history to confirm whether all were of the same quality to start with.
-            
-- The findings repo (for high-performing wardens’ submissions + Validated submissions) will also have duplicate submissions.
-    - The Judge is responsible for reviewing and finalizing dupe sets, and assessing quality.
-
-## Validators can improve HM submissions
-
-Validators may improve High and Medium-risk submissions (HMs); they may not improve QA or Gas reports.
-
-If a validator chooses to improve a submission:
-
-- The original submission is preserved for the judge to see
-- The judge evaluates validators’ enhancements and whether they validated, proved, or enhanced them. (See “Awarding” section below.)
-- Improved submissions must share the same root cause as the original submission.
-
-*N.B. If the finding is already present in the findings repo, then improved submissions will be judged in their original versions, and Validator improvements will be disregarded.* Validators should check the findings repo for duplicates prior to improving a submission.
-
-## Awarding
-
-- The Validator pool takes the place of the Lookout pool
-- Validators earn their share of the Validator pool based on:
-    - Number of issues triaged,
-    - The phase during which the issues were triaged, and
-    - Final accuracy.
-- For Validator-improved submissions:  if the judge believes the validator added a measurable enhancement, they get a split of the value of the issue:
-    - 25% cut → small enhancement
-    - 50% cut → med enhancement
-    - 75% cut → large enhancement
-- Phases and points:
-    - **Round 1** validations are worth 1 point each
-    - **Round 2 (”limbo”)** validations are assigned a value on a curve based on the order of the submission (the "nonce") such that the later the submission is validated the more it is worth. The function for this is `steepness ^ (totalNonces - nonceOrder)` where steepness is set to `1.015`
-    - Passing costs `0.5` (ie passing twice neutralizes the value of 1 successful validation)
-    - The validator's accuracy in this competition has an impact on their overall point total. `points = ((roundOneTotal + limboTotal - (pass*y)) * (accuracy ^x)` where `y` is the `pass cost` (`0.5` by default) and `x` is the accuracy decrementer (`3` by default).
-        - For Round 2 (”limbo”) submissions, the value of the accuracy decrementer is 50% of the nonce value.
-    - Then the payout is just like shares of other award pools: `validatorPayout = (thisValidatorPoints / allValidatorPoints) * validatorPool`
-
 ## Miscellaneous
 
-- Judges can play the Judge and Validator role on the same audit, but are not eligible for any HM pool payouts on audits they judge — even if they enhance an issue.
+- Judges can play the Judge and Validator role on the same audit.
 - If a Warden plays the Validator role on an audit in which they competed as a Warden, they must forgo any Warden awards they would have received for their findings in said audit.
 - Both the Validation repo and the Findings repo will be open to wardens with the SR role, for the purposes of post-judging QA.
     - All PJQA requests must be posted in the Github Discussion in the findings repo.
     - QA and Gas reports closed by Validators (i.e. *not* added to the findings repo) are NOT eligible 
 - Both repos will be made public when the audit report is published.
-- Validators’ accuracy score as a warden is impacted by their accuracy as Validators:
-    - 50% of Validators’ *round 1* validator accuracy is applied to their personal accuracy score.
-    - Limbo phase accuracy only has a 25% impact on their accuracy.
-    - All report types (High, Medium, QA, and Gas) are counted towards accuracy scores.
-    - False positives count 50% toward Validators' submission accuracy
-    - False negatives count 100% toward Validators' submission accuracy
-    - In other words, each false negative is double the negative value of false positives in the ‘incorrect’ count.
-- [Certified Security Researchers](../certified-contributors/sr-backstage-wardens.md) may appeal improvements made by Validators, and request that the judge review their original submission during post-judging QA.
+- Validators’ accuracy score is tracked by C4 as a separate metric from their warden accuracy score. 
 
 # Becoming a Validator
 
@@ -148,7 +80,7 @@ Complete [this application form](https://code4rena.com/validator-application) an
 
 **Note:** Validator applications are reviewed during a one-week period each month. Notices of application and review windows will be posted in the C4 Discord server.
 
-**Validator selection process**
+## Validator selection process
 
 Being a Validator is a critical role and we only have so many spots.
 

--- a/structure/account-management.md
+++ b/structure/account-management.md
@@ -53,7 +53,7 @@ Certified and SR wardens should verify their Github accounts in order to access 
 To verify your GitHub account on Code4rena, follow these steps:
 
 1. Log in to your Code4rena account.
-2. Go to the **Account Settings** page.
+2. Go to the [**Account Settings**](https://code4rena.com/account) page.
 3. Look for the section labeled **User Information**.
 4. Check if your GitHub account is verified.
 5. If not verified, click the **Verify** link next to "Please verify your GitHub account."

--- a/structure/account-management.md
+++ b/structure/account-management.md
@@ -3,9 +3,9 @@
 To register, follow these steps:
 
 1. Go to [code4rena.com/register](https://code4rena.com/register/account).
-2. Fill in your information. You can choose to connect a web3 wallet for authorization or use only a username and password.
-3. Provide your Polygon wallet payment address for audit rewards.
-4. Note: You can update any of your details at any time after signup, except for your username.
+2. Fill in your information. You can choose to connect a web3 wallet for authorization or use only a username and password. 
+   - Note: You can update any of your details at any time after signup, **except for your username.**
+3. **Wardens:** Provide your Polygon wallet payment address for audit rewards.
 
 ## Account setup process
 
@@ -20,9 +20,11 @@ After registration, complete the following steps to set up your account:
    - Click the verification link to confirm your email address.
 4. Once both verifications are complete, your account setup will finalize, granting you access to Code4rena's platform!
 
-## Teams
+## Warden teams
 
 Once individual team members are authenticated, they will be able to submit findings as individuals or on behalf of the team.
+
+---
 
 ## FAQ / troubleshooting
 
@@ -41,6 +43,25 @@ If you can't see most channels in the Code4rena Discord server, your Discord ver
 1. **Check [discord.com](https://discord.com) in your web browser.** You may be logged into a different Discord account in your web browser, and if so, that Discord account has received the warden role instead.
 2. Log out of Discord.
 3. **Perform the Discord verification again:** Log into the account you want associated with your C4 user account, in the same browser you are using to interact with code4rena.com. Next, head to your account settings and perform the Discord verification again.
+
+### Github verification (optional)
+
+Certified and SR wardens should verify their Github accounts in order to access private repos. 
+
+**Note:** Ensure that you are logged in to the correct GitHub account before starting the verification process.
+
+To verify your GitHub account on Code4rena, follow these steps:
+
+1. Log in to your Code4rena account.
+2. Go to the **Account Settings** page.
+3. Look for the section labeled **User Information**.
+4. Check if your GitHub account is verified.
+5. If not verified, click the **Verify** link next to "Please verify your GitHub account."
+6. You will be redirected to GitHub for authorization.
+7. On the GitHub authorization page, click **Authorize**.
+8. You will be redirected back to Code4rena, and you should see "✓ GitHub verified" if successful.
+
+Your GitHub account is now successfully linked and verified on Code4rena!
 
 ### Wallet connect issues
 
@@ -86,6 +107,8 @@ To edit your payment address:
 3. Go to [code4rena.com/account](https://code4rena.com/account) and find 'Payment Information'.
 4. Click 'Edit' and enter your desired payment address.
 Note: for each contest, C4 distributes awards to the payment address on file *at the time of award calculation*.
+
+---
 
 ### My problem is not solved!
 


### PR DESCRIPTION
- [x] Update Validators page to reflect single validator processes
- [x] Clarify that Pro League wardens' submissions are sent directly to findings repo
- [x] Move user accounts page out of wardens section 
- [x] add GH verification steps to account management page