### PR TITLE
Remove org repo links; update outdated info

### DIFF
--- a/awarding/fairness-and-validity/README.md
+++ b/awarding/fairness-and-validity/README.md
@@ -10,19 +10,17 @@ These are the fundamental principles that underly how we look at the question of
 1. When we depend too heavily on the judgment of individuals, we work to improve the system long-term in iterative and sustainable ways.
 1. Because we are working every day within the constraints of the systems we have, we aim to be patient with the time and consideration that improvement takes and gracious toward the individuals tasked by the system with making difficult decisions.
 
-It may be worth reading [this longer piece](https://github.com/code-423n4/org/discussions/36) on the topic of how our system has evolved.
-
 # Expectations of participants
 
-- Sponsors should be able to trust that Code4rena as a system is working to help them secure their code and that their funds are a good investment toward that end.
-- Wardens should be able to have clear rule expectations of contests they contribute to—as clear as possible within the constraints.
-- Judges should be impartial and free to act independently to do what they see best in a given contest within the guidelines they are provided.
+- [Sponsors](https://docs.code4rena.com/roles/sponsors/) should be able to trust that Code4rena as a system is working to help them secure their code and that their funds are a good investment toward that end.
+- [Wardens](https://docs.code4rena.com/roles/wardens/) should be able to have clear rule expectations of contests they contribute to—as clear as possible within the constraints.
+- [Judges](https://docs.code4rena.com/roles/judges/) should be impartial and free to act independently to do what they see best in a given contest within the guidelines they are provided.
 
 # What constitutes a ‘valid’ report’?
 
 The validity of an audit report submission is not based on whether it is ‘true’ or not. A report may contain a finding which is factually 'true' (the most literal interpretation of 'valid'), but if it does not add value or if it is not presented in such a way that adds value to a sponsor, it may be deemed invalid by a judge.
 
-This may seem harsh and exclusive, but it is essential to consider that Code4rena runs audit contests, not gotcha-hunts, and Code4rena offers guaranteed payout for valid submissions. This means that wardens are providing a service to sponsors and the product of those services should meet what judges feel is a minimum standard in order to be deemed of value.
+This may seem harsh and exclusive, but it is essential to consider that Code4rena runs audit competitions, not gotcha-hunts. This means that wardens are providing a service to sponsors and the product of those services should meet what judges feel is a minimum standard in order to be deemed of value.
 
 Auditing is serious, disciplined work that should provide high value consultative expertise to the people paying for the work.
 
@@ -32,18 +30,14 @@ While this may be seen as ‘inconsistent’, it is also true that standards wit
 
 The correct assessment when this happens is not that a judge is being inconsistent, it is that they have objectively observed that the quality of competition has increased, and that observation shapes their view of the whole set of submissions; they are consistent in valuing submissions in the context of each other, which is a central way that performance in a competition is measured.
 
-Per [the Autumn 2023 Supreme Court verdicts](https://docs.code4rena.com/awarding/judging-criteria/supreme-court-decisions-fall-2023), it is within the judge’s discretion to invalidate all of a warden’s findings in a particular contest in the case of repeated low-quality submissions. For more details on this, please see ["Good citizenship" in the Submission guidelines](https://docs.code4rena.com/roles/wardens/submission-guidelines#good-citizenship-is-a-requirement-for-compensation).
+Per [the Autumn 2023 Supreme Court verdicts](https://docs.code4rena.com/awarding/judging-criteria/supreme-court-decisions-fall-2023), it is within the judge’s discretion to invalidate all of a warden’s findings in a particular contest in the case of repeated low-quality submissions, or for any other breach of the ["Good citizenship" requirements](https://docs.code4rena.com/roles/wardens/submission-guidelines#good-citizenship-is-a-requirement-for-compensation).
 
 # If you disagree with a judge's decision
 
-If you disagree with a decision, and you do not have [the C4 SR role](https://docs.code4rena.com/roles/certified-contributors/sr-backstage-wardens) (formerly +backstage role), there's nothing further that can be done or changed; the judge's decisions are final. 
+If you disagree with a decision, and you do not have [the C4 SR role](https://docs.code4rena.com/roles/certified-contributors/sr-backstage-wardens), there's nothing further that can be done or changed; the judge's decisions are final. 
 
-However, if the concern regarding judging is focused on a matter of inconsistency or process or lack of clarity in the rules, you are encouraged to review the issues in https://github.com/code-423n4/org/issues and:
+However, if the concern regarding judging is focused on a matter of inconsistency or process or lack of clarity in the rules, you are encouraged to share your suggestions for future improvements to C4 processes in the [#suggestion-box channel in the Code4rena Discord server](https://discord.com/channels/810916927919620096/824698635815223316), as follows:
 
-1. See if one of the problems described there matches the type of issue you have experienced. If so, add a purely fact-based comment with additional information and another point of evidence of it being a challenge.
-
+1. First, search Discord to see if the type of issue you have experienced has already been raised for discussion. If so, add a purely fact-based comment with additional information and another point of evidence of it being a challenge.
 2. See if any of the suggestions described there would be useful to improving the case you have in mind. If so, feel free to add your thoughts in support.
-
-3. IF a relevant type of issue is not already addressed there which doesn't represent the categorical concern you have, you can feel free to open an issue.
-
-The purpose of issues in that repo is not to post grievances about specific issues but about to identify places where the process can be improved and ways we can improve it. 
+3. If a relevant type of issue is not already addressed there which doesn't represent the concern you have, you can feel free to open a new discussion.

--- a/awarding/incentive-model-and-awards/README.md
+++ b/awarding/incentive-model-and-awards/README.md
@@ -1,6 +1,6 @@
 # Incentive model and awards
 
-To incentivize **wardens**, C4 uses a unique scoring system with two primary goals: reward participants for finding unique bugs and also to make the audit resistant to Sybil attack. A secondary goal of the scoring system is to encourage participants to form teams and collaborate.
+To incentivize **wardens**, C4 uses a unique scoring system with two primary goals: reward participants for finding unique vulnerabilities and also to make the audit resistant to Sybil attack. A secondary goal of the scoring system is to encourage participants to form teams and collaborate.
 
 **Judges** are incentivized to review findings and decide their severity, validity, and quality by receiving a share of the prize pool themselves.
 
@@ -11,27 +11,27 @@ To incentivize **wardens**, C4 uses a unique scoring system with two primary goa
 
 We periodically ship bug fixes that may produce minor differences in award calculation results over time. 
 
-## High and Medium Risk bugs
+## High and Medium Risk findings
 
-Wardens are given shares for bugs discovered based on severity, and those shares give the owner a pro rata piece of the pie:
+Wardens are given shares for findings discovered based on severity, and those shares give the owner a pro rata piece of the pie:
 
 `Med Risk Slice: 3 * (0.85 ^ (split - 1)) / split`\
 `High Risk Slice: 10 * (0.85 ^ (split - 1)) / split`
 
-Please note that findings with partial credit still count as 1 finding in the algorithm. \
+Please note that submissions with partial credit still count as 1 submission in the algorithm. \
 During awarding, each award is redeemed for: `award pool / pie / slice`.
 
 ### Bonus for best / selected for report
 
 For each unique High or Medium finding, the submission selected for inclusion in the audit report receives a 30% slice bonus. The `pie` (total of slices) is also increased accordingly.
 
-Let's look at an example of a set of High risk duplicates, with 3 satisfactory findings.
+Let's look at an example of a High risk finding (set of duplicates), containing 3 satisfactory submissions.
 
 As per the formula, the pie would be: \
 `10 * (0.85 ^ (findingCount - 1)) = 7.225`
 
-Warden A's finding is selected for report; therefore the pie is adjusted as follows: \
-`new pie = previous pie + [selected finding's slice] * 0.3` \
+Warden A's submission is selected for report; therefore the pie is adjusted as follows: \
+`new pie = previous pie + [selected submission's slice] * 0.3` \
 `=> 7.225 + ( 2.408333333333333 * 0.3 ) = 7.9475`
 
 The resulting awards are:
@@ -52,7 +52,7 @@ Both bonuses weigh Highs more heavily than Mediums, similarly to Code4rena's sta
 
 **Top Hunter score**
 
-Each participant's High- and Medium-risk findings are used to calculate the Top Hunter score. The scoring logic is as follows:
+Each participant's High- and Medium-risk submissions are used to calculate the Top Hunter score. The scoring logic is as follows:
 
 - Only full-credit HM findings with fewer than 5 submissions in the findings set count towards the top hunter score.
 - For each High-risk finding, score += 10 * 1/x, where x = number of duplicates 
@@ -82,9 +82,9 @@ Partial credit duplicates (see next section) do not count towards the  Top Gathe
 
 ### Duplicates getting partial credit
 
-All issues which identify the same functional vulnerability will be considered duplicates regardless of effective rationalization of severity or exploit path.
+All submissions that identify the same functional vulnerability will be considered duplicates regardless of effective rationalization of severity or exploit path.
 
-However, any submissions which do not identify or effectively rationalize the top identified severity case may be judged as “partial credit” and may have their shares  divided at judge’s sole discretion (e.g. 25%, 50%, or 75% of the shares of a satisfactory submission in the duplicate set).
+However, any submissions which do not identify or effectively rationalize the top identified severity case may be judged as “partial credit” and may have their shares divided at the judge’s sole discretion (e.g. 25%, 50%, or 75% of the shares of a satisfactory submission in the duplicate set).
 
 Awards for partial duplicates are calculated as follows: 
 
@@ -159,7 +159,7 @@ Low severity and governance/centralization risk findings are submitted as a **si
 
 QA and gas optimization reports are awarded on a curve based on the judge’s score.
 
-- QA reports compete for a share of 4% of the prize pool (e.g. $2,000 for a $50,000 audit);
+- QA reports typically compete for a share of ~4% of the prize pool (e.g. $2,000 for a $50,000 audit);
 - The gas optimization pool varies from audit to audit;
 - QA and Gas optimization reports are awarded on a curve.
 
@@ -180,34 +180,6 @@ Tie votes are handled as follows:
 Satisfactory reports not among the winning reports will not be awarded -- but will count towards wardens' accuracy scores.
 
 In the unlikely event that zero high- or medium-risk vulnerabilities are found, the HM award pool will be divided among all satisfactory QA reports based on the QA Report curve, **unless otherwise stated in the audit repo.** 
-
-## Z Pools and Dark Horse bonuses
-
-If a Z pool is listed among an audit's award pools, then it has a Z pool, which may be repurposed (in part or whole) as a Dark Horse pool. For audits with a Z pool: 
-
-- `n` [Zenith](https://code4rena.com/zenith) Researchers (ZRs) are designated as leads for the audit ("LZRs"), with teams counting as one.
-- Z pool is split among LZRs based on their [Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors), using the [ranked curve](https://docs.code4rena.com/awarding/incentive-model-and-awards/curve-logic#dark-horse-bonuses-ranked-curve-awarding)
-- LZRs also compete for a portion of HM awards and are eligible for Hunter/Gatherer bonuses
-
-### Dark Horse bonus pool
-
-Dark Horse is (1) a non-LZR who (2) finishes in the top `n + 3`, and (3) outperforms (or ties) the top-ranked LZR auditor based on [Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors) 
-
-Dark Horse awards come out of the Z pool.
-
-- If an LZR ranks outside the top `n` (by [Top Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors)):
-    - 50% of their share of the Z pool goes to the Dark Horse bonus pool
-- If an LZR ranks outside the top `n + 3` (by [Top Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors)):
-    - The LZR forfeits their share of the Z pool (but are still eligible for HM / QA awards)
-    - 50% of their share of the Z pool goes to the Dark Horse bonus pool
-    - 50% of their share of the Z pool is refunded to sponsor
-- Dark Horse awards are distributed using C4’s ranked curve.
-
-### Specific edge cases:
-
-- If no lead ranks outside the top `n`, no Dark Horse bonus is awarded.
-- In the event that no LZRs rank in the top `n + 3` the Dark Horse pool will be distributed, but only the top `n` ranked competitors will earn the Dark Horse achievement for the competition.
-- Any unused portion of the Z pool is returned to the Sponsor
 
 ## Satisfactory / unsatisfactory submissions
 

--- a/awarding/incentive-model-and-awards/historical-info.md
+++ b/awarding/incentive-model-and-awards/historical-info.md
@@ -2,7 +2,7 @@
 
 ## Submission types paused
 
-As of April 30, 2024, the following submission types are paused:
+As of April 30, 2024, the following submission types are deprecated:
 
 ### Bot reports
 
@@ -19,11 +19,35 @@ By designating a portion of the pool in this direction, Code4rena creates a sepa
 
 ### Analyses
 
-Analyses share high-level advice and insights from wardens' review of the code.
+An analysis is a written submission outlining:
 
-Where individual findings are the "trees" in an audit, the Analysis is a "forest"-level view.
+- Wardens' analysis of the codebase as a whole and any observations or advice they have about architecture, mechanism, or approach
+- Broader concerns like systemic risks or centralization risks
+- The approach taken in reviewing the code
+- New insights and learnings from the audit
 
-Analyses compete for a portion of each audit's award pool, and are graded and awarded similarly to QA and Gas Optimization reports.
+If individual findings are trees, Analyses are the forest. They provide wardens with an opportunity to contribute value through high level insights and advice that aren't necessarily covered by specific bugs -- and a way to get credit for doing so.
+
+Each Analysis is judged based on quality and thoroughness as compared with other Analyses, with awards distributed on a curve. Wardens are encouraged to read the top-scoring Analyses from past Code4rena audits, which are highlighted in [C4's audit reports](https://code4rena.com/reports).
+
+Analyses are judged A, B, or C, with C being unsatisfactory and ineligible for awards. The judge selects the best Analysis for inclusion in the audit report.
+
+The Autumn 2023 Supreme Court session provided further judging guidelines for Analyses, saying they should provide "[actionable] insight on improvement steps of outlined characteristics." 
+
+Areas of interest include:
+- Full representation of the project’s risk model:
+  - Admin abuse risks
+  - Systemic risks
+  - Technical risks
+  - Integration risks
+  - Non-standard token risks (if in scope)
+- Software engineering considerations
+- In-depth architecture assessment of business logic 
+- Testing suite
+- Weakspots and any single points of failure
+
+Merely repeating the code functionality in pseudo-documentation is not considered valuable information.
+
 
 ## Understanding historical grading for QA, Gas, and Analysis reports
 
@@ -173,3 +197,31 @@ We can see here that the logic behind the `partial-` labels only impacts the awa
 **Conclusion:**
 
 Only the award amounts for "partial" findings have been reduced, in line with expectations. The aim of this adjustment is to recalibrate the rewards allocated for these specific findings. Meanwhile, the awards for full-credit findings remain unchanged.
+
+## Z Pools and Dark Horse bonuses
+
+If a Z pool is listed among an audit's award pools, then it has a Z pool, which may be repurposed (in part or whole) as a Dark Horse pool. For audits with a Z pool: 
+
+- `n` [Zenith](https://code4rena.com/zenith) Researchers (ZRs) are designated as leads for the audit ("LZRs"), with teams counting as one.
+- Z pool is split among LZRs based on their [Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors), using the [ranked curve](https://docs.code4rena.com/awarding/incentive-model-and-awards/curve-logic#dark-horse-bonuses-ranked-curve-awarding)
+- LZRs also compete for a portion of HM awards and are eligible for Hunter/Gatherer bonuses
+
+### Dark Horse bonus pool
+
+Dark Horse is (1) a non-LZR who (2) finishes in the top `n + 3`, and (3) outperforms (or ties) the top-ranked LZR auditor based on [Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors) 
+
+Dark Horse awards come out of the Z pool.
+
+- If an LZR ranks outside the top `n` (by [Top Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors)):
+    - 50% of their share of the Z pool goes to the Dark Horse bonus pool
+- If an LZR ranks outside the top `n + 3` (by [Top Gatherer score](https://docs.code4rena.com/awarding/incentive-model-and-awards#bonuses-for-top-competitors)):
+    - The LZR forfeits their share of the Z pool (but are still eligible for HM / QA awards)
+    - 50% of their share of the Z pool goes to the Dark Horse bonus pool
+    - 50% of their share of the Z pool is refunded to sponsor
+- Dark Horse awards are distributed using C4’s ranked curve.
+
+### Specific edge cases:
+
+- If no lead ranks outside the top `n`, no Dark Horse bonus is awarded.
+- In the event that no LZRs rank in the top `n + 3` the Dark Horse pool will be distributed, but only the top `n` ranked competitors will earn the Dark Horse achievement for the competition.
+- Any unused portion of the Z pool is returned to the Sponsor

--- a/awarding/judging-criteria/README.md
+++ b/awarding/judging-criteria/README.md
@@ -1,41 +1,16 @@
 # Judging criteria
 
-## Submission Review Process
+## Submission review process
 
 C4 strives to ensure a deliberate and transparent process for reviewing and judging submissions.
 
-At the end of a given audit period, all submissions will be reviewed and categorized based on these criteria. Pending sponsor review, audit reports will be shared publicly on the [C4 Audit Report page](https://code4rena.com/reports). Audit results are shared on the C4 Discord and winners announced on [C4's X account](https://x.com/code423n4).
+At the end of a given audit period, all submissions will be reviewed and categorized based on these criteria. Pending sponsor review, audit reports will be shared publicly on the [C4 Audit Report page](https://code4rena.com/reports). Audit results are shared on the C4 Discord and winners announced on [C4's X account](https://x.com/code4rena).
 
 Submissions are also judged based on grammar, conciseness, and formatting.
 
-## Best Current Practices
+## Duplicate submissions
 
-The [Code4rena org repo](https://github.com/code-423n4/org) documents open discussions and emergent best practices for judging C4 audits. Judges are encouraged to review [open issues in that repo](https://github.com/code-423n4/org/issues) regularly.
-
-## Duplicate Submissions
-
-Should multiple submissions describing the same vulnerability be submitted, Judges have the discretion to place these bugs into the same bucket, in which case, the award will be shared among those who submitted. However, multiple submissions from the same warden (or warden team), are treated as one by the awarding algorithm and do not split the pie into smaller pieces.
-
-### Penalty / Award Standardization - Duplicate Submission PoC Thoroughness
-
-The lack of certain components has the following affect scoring:
-
-The requisites of a full mark submission are:
-- Identification and demonstration of the root cause
-- Identification and demonstration of the maximum achievable impact of the root cause
-
-For a demonstration to be satisfactory, it can take the form of:
-
-1. A step-by-step explanation from root cause to impact, with either attached code snippets or a coded POC.
-2. At the judge’s discretion, a highly-standard issue can be accepted with less detail provided.
-
-A lack of identification of the root cause is grounds for partial scoring, downgrading, or invalidating the issue.
-
-A lack of identification of maximal impact is grounds for partial scoring or downgrading of the issue.
-
-Additional factors that can be taken into account for partial scoring include:
-- Quality of the submission in the form of writing or presentation quality
-- Lack or incorrectness of the remediation steps
+Should multiple submissions describing the same vulnerability be submitted, Judges have the discretion to place these submissions into the same finding (duplicate group), in which case, the award will be shared among those who submitted. Note that multiple submissions from the same warden (or warden team) are treated as one by the awarding algorithm, and do not split the award into smaller pieces.
 
 ### Similar exploits under a single issue
 
@@ -45,7 +20,28 @@ More specifically, if fixing the Root Cause (in a reasonable manner) would cause
 
 Given the above, when similar exploits would demonstrate different impacts, the highest, most irreversible would be the one used for scoring the finding. Duplicates of the finding will be graded based on the achieved impact relative to the submission selected for inclusion in the report.
 
-### Findings published in prior audit reports
+### Penalty / award standardization - duplicate submission PoC thoroughness
+
+The lack of certain components has the following affect scoring:
+
+The requisites of a full mark submission are:
+- Identification and demonstration of the root cause
+- Identification and demonstration of the maximum achievable impact of the root cause
+
+For a demonstration to be satisfactory, it can take the form of:
+
+1. A step-by-step explanation from root cause to impact, with either attached code snippets or a coded PoC.
+2. At the judge’s discretion, a high-standard issue can be accepted with less detail provided.
+
+A lack of identification of the root cause is grounds for partial scoring, downgrading, or invalidating the issue.
+
+A lack of identification of maximal impact is grounds for partial scoring or downgrading of the issue.
+
+Additional factors that can be taken into account for partial scoring include:
+- Quality of the submission in the form of writing or presentation quality
+- Lack or incorrectness of the remediation steps
+
+## Findings published in prior audit reports
 
 Findings from previous audit reports listed in the audit repo `README` should generally be considered as known issues and therefore out of scope, especially if they were evaluated as acknowledged/wontfix by the sponsor. 
  
@@ -58,11 +54,11 @@ Judges should use their discretion to assess whether the submission a) provides 
 
 Each audit may include code that is explicitly in scope and out of scope, and specific issues which also may be identified as out of scope.
 
-Wardens who adhere to the audit guidelines and submit valid medium/high severity bugs which are not explicitly excluded from scope will earn a guaranteed payment.
+Wardens who adhere to the audit guidelines and submit valid medium/high severity vulnerabilities which are not explicitly excluded from scope will earn a guaranteed payment.
 
-Wardens _may_ elect to argue to bring things into scope—either by making the case that an issue poses a more urgent threat than identified or by submitting a medium or high severity finding in code which is out of scope. However, it is up to judges' absolute discretion whether to include these findings and award them, and these issues should include a clear argument as to why the items merit being brought into scope.
+Wardens _may_ elect to argue to bring things into scope—either by making the case that an issue poses a more urgent threat than identified or by submitting a medium or high severity vulnerability in code which is out of scope. However, it is up to judges' absolute discretion whether to include these findings and award them, and these issues should include a clear argument as to why the items merit being brought into scope.
 
-In the interest of everyone's time, **please do not offer QA or gas reports on any code or known issues which are identified as out of scope.**
+In the interest of everyone's time, **QA or gas reports should not include findings relating to any code or known issues which are identified as out of scope.**
 
 ## Acceptance of submissions based on automated findings
 
@@ -72,22 +68,22 @@ Wardens and judges are recommended to read [the Supreme Court's verdict on this 
 
 The scoring system has three primary goals:
 
-* Rewarding Wardens for finding unique bugs
-* Hardening C4 code audits to Sybil attacks
+* Rewarding Wardens for finding unique vulnerabilities
+* Hardening C4 audits to Sybil attacks
 * Encouraging coordination by incentivizing Wardens to form teams.
 
 ### QA reports (Low risk and Governance/Centralization risk)
 
-Low risk and Governance/Centralization risk findings must be submitted as a _single_ QA report per warden. We allocate a **fixed 4% of prize pools toward QA reports.**
+Low risk and Governance/Centralization risk findings must be submitted as a _single_ QA report per warden. Most Code4rena audits allocate approximately **4% of prize pools toward QA reports.**
 
 QA reports should include:
 
 * all low severity findings; and
-* all Governance/Centralization risk findings.
+* all governance/centralization risk findings.
 
 Each QA report should be assessed based on report quality and thoroughness as compared with other reports, with awards distributed on a curve. 
 
-Judges have discretion to assign a lower grade to wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts). Judges may also raise the severity of a QA finding at their discretion. 
+Judges have discretion to assign a lower grade to wardens overstating the severity of QA issues (submitting low/non-critical issues as med/high in order to angle for higher payouts). 
 
 ### Gas reports
 
@@ -98,38 +94,3 @@ Gas pools are optional, but for audits that include Gas optimizations, the preci
 ## Estimating Risk
 
 See [Severity Categorization](https://docs.code4rena.com/awarding/judging-criteria/severity-categorization).
-
-## Other report types
-
-### Analysis
-
-_This report type is currently paused, and is not accepted for audits starting on or after April 30, 2024._
-
-Analyses are judged A, B, or C, with C being unsatisfactory and ineligible for awards. The judge selects the best Analysis for inclusion in the audit report.
-
-An analysis is a written submission outlining:
-
-- Wardens' analysis of the codebase as a whole and any observations or advice they have about architecture, mechanism, or approach
-- Broader concerns like systemic risks or centralization risks
-- The approach taken in reviewing the code
-- New insights and learnings from the audit
-
-If individual findings are trees, Analyses are the forest. They provide wardens with an opportunity to contribute value through high level insights and advice that aren't necessarily covered by specific bugs -- and a way to get credit for doing so.
-
-Each Analysis is judged based on quality and thoroughness as compared with other Analyses, with awards distributed on a curve. Wardens are encouraged to read the top-scoring Analyses from past Code4rena audits, which are highlighted in [C4's audit reports](https://code4rena.com/reports).
-
-The Autumn 2023 Supreme Court session provided further judging guidelines for Analyses, saying they should provide "[actionable] insight on improvement steps of outlined characteristics." 
-
-Areas of interest include:
-- Full representation of the project’s risk model:
-  - Admin abuse risks
-  - Systemic risks
-  - Technical risks
-  - Integration risks
-  - Non-standard token risks (if in scope)
-- Software engineering considerations
-- In-depth architecture assessment of business logic 
-- Testing suite
-- Weakspots and any single points of failure
-
-Merely repeating the code functionality in pseudo-documentation is not considered valuable information.

--- a/awarding/judging-criteria/severity-categorization.md
+++ b/awarding/judging-criteria/severity-categorization.md
@@ -68,19 +68,15 @@ Loss of **matured** yield should be regarded as an impact similar to any other l
 Loss of **unmatured** yield or yield in motion shall be capped to medium severity.
 
 ## Approve race condition - NC or Invalid
-
+Notes from [the Fall 2023 Supreme Court decisions](https://docs.code4rena.com/awarding/judging-criteria/supreme-court-decisions-fall-2023/): 
 - We have long rejected the finding as anything above NC
 - OZ has deprecated increaseAllowance and decreaseAllowance
 - We officially confirm:
-```
   - Approve and safeApprove front-run is NOT a valid vulnerability
   - Approve and safeApprove are NOT deprecated
   - increaseAllowance and decreaseAllowance ARE deprecated, although usage of those functions
-    is not regarded as a bug report.
-```
+  is not regarded as a bug report.
 
 ## Severity Standardization Process
 
-Judges and the C4 community collaborate in open discussions of severity standards, which has created an evolving meta that's unique to C4 and enables both the organizations being audited and the auditors themselves to be part of a platform that is self-reflective and is constantly iterating on its processes for their collective benefit.
-
-The rules above act as a starting point, and these open discussions act as a growing set of case law examples. You can view the open forum where these discussions are held [here](https://github.com/code-423n4/org/issues?q=is%3Aissue+is%3Aopen+label%3Arules).
+Judges and the C4 community collaborate in open discussions of severity standards via [the Code4rena Discord server](https://discord.gg/code4rena).

--- a/roles/wardens/README.md
+++ b/roles/wardens/README.md
@@ -12,9 +12,9 @@ Code4rena audits let people of a wide range of skill levels get rewarded while s
 
 Anyone can register to participate in an audit. [Register here](https://code4rena.com/register/account), confirm your email address, then join [our Discord](https://discord.gg/code4rena) to get started.
 
-Once you've completed those verification steps, [have a look at the C4 website](https://code4rena.com), where you'll find a list of open and upcoming audits, along with their pool size, start and end date, and other relevant information. Active audits will typically include a link to the code repo, as well as the submission form for findings.
+Once you've completed those verification steps, [have a look at the C4 website](https://code4rena.com/audits/), where you'll find a list of open and upcoming audits, along with their pool size, start and end date, and other relevant information. Active audits will typically include a link to the code repo, as well as the submission form for findings.
 
-As a reminder, for Wardens participating in code audits, please familiarize yourself with the [submission policy](submission-policy.md) and [judging criteria](../../awarding/judging-criteria/) prior to participating.
+Please familiarize yourself with the [submission policy](submission-policy.md) and [judging criteria](../../awarding/judging-criteria/) prior to participating.
 
 ### Registering a team
 
@@ -24,7 +24,7 @@ Once a team is created, you have the ability to add/remove members and update yo
 
 All team registrations and updates will create pull requests that are flagged for the C4 team to review and approve. Please allow 24-48 business hours for processing.
 
-❗️**Important note: Team awards are sent as a single payment to **_**one**_** wallet.** We strongly recommend using a multisig wallet, or a tool like [PaymentSplitter](https://docs.openzeppelin.com/contracts/4.x/api/finance#PaymentSplitter), to distribute awards among your team members. Note that C4 does not track which team member submitted each finding; your team is responsible for keeping track of that information, and distributing awards. The team structure at C4 is designed so that you submit as a team and get paid as a team.
+❗️**Important note: Team awards are sent as a single payment to _one_ wallet.** We strongly recommend using a multisig wallet, or a tool like [PaymentSplitter](https://docs.openzeppelin.com/contracts/4.x/api/finance#PaymentSplitter), to distribute awards among your team members. Note that C4 does not track which team member submitted each finding; your team is responsible for keeping track of that information, and distributing awards. The team structure at C4 is designed so that you submit as a team and get paid as a team.
 
 ### Audit timeline
 
@@ -37,13 +37,12 @@ When audit sponsors come to Code4rena for an audit, we always encourage them to 
 
 When a sponsor designates a team member who is available for questions, that person will introduce themselves in the C4 Discord (in an audit-specific channel). You may start a private thread with them if you have questions; however, please be sure to first review all documentation for the audit to ensure the answer hasn't already been provided.
 
-_Note: general questions about such topics as auditing or C4 processes should be asked in the `Questions` or `Wardens` channels in the C4 Discord, not directed to the sponsor._
+_Note: general questions about such topics as auditing or C4 processes should be asked in the `#questions` or `#wardens` channels in the C4 Discord, not directed to the sponsor._
 
 ### ⏩ TL;DR
 
-* Turn in your reports before the audit end time.
+* Turn in your reports before the submission deadline.
 * For each audit, submit your Medium and High risk findings individually.
 * Bundle all of your low-risk and governance / centralization risk findings into a single QA report.
-* Similarly, list _all_ of your gas optimizations together in a single Gas report.
-* Be sure to [register your handle and Polygon address](https://code4rena.com/register/account) to receive your share.
+* Be sure to [register your handle and wallet address](https://code4rena.com/register/account) to receive your share.
 * Publicly disclosing (e.g. publishing or discussing) any discovered bugs or vulnerabilities before the audit report has been published is grounds for disqualification from all C4 events.

--- a/roles/wardens/submission-guidelines.md
+++ b/roles/wardens/submission-guidelines.md
@@ -6,15 +6,15 @@ Best practices and recommendations for submitting to Code4rena competitions. Ple
 
 C4 accepts vulnerability reports via the audit submission form.
 
-In order to help us triage and prioritize submissions, please ensure that your reports:
+In order to help us triage and prioritize findings, please ensure that your submissions:
 
-- Are submitted no later than the audit stop time.
-- Use the audit submission process.
-- Follow the correct report format. (See next section.)
-- Describe the location the vulnerability was discovered and the potential impact of exploitation.
-- Offer a detailed description of the steps needed to reproduce the vulnerability (proof of concept scripts or screenshots are helpful).
-- Have not been surfaced as "known issues" (see audit repo README for details).
-- Are written in English, if possible.
+- Are submitted before the submission deadline;
+- Use the correct submission form;
+- Follow the correct format (see next section);
+- Describe the location the vulnerability was discovered and the potential impact of exploitation;
+- Offer a detailed description of the steps needed to reproduce the vulnerability (coded Proof of Concept or screenshots are encouraged);
+- Have not been surfaced as "known issues" (see audit repo README for details); and
+- Are written in English.
 
 ## Submission types
 
@@ -25,15 +25,15 @@ In order to help us triage and prioritize submissions, please ensure that your r
 
 ### QA reports (low/governance)
 
-Low and non-critical findings must be submitted as a single QA report per warden. We allocate **4% of most prize pools toward QA reports.**
+Low and non-critical findings must be submitted as a single QA report per warden. 
 
 Your QA report should include:
 - all Low severity findings
 - all Governance / Centralization risk findings (including centralization risks, systemic risks, and admin privileged functions)
-- Non-critical findings are discouraged. 
+
+**Non-critical findings are discouraged.** 
 
 Formatting:
-
 - Wardens are encouraged to use a standard format to label findings, e.g. `L-01`, `L-02`, etc. for low-risk findings, and `C-01`, `C-02`, etc. for centralization/governance findings. 
 - Please do not use `G-` prefixes as those are typically used to identify Gas optimization findings.
 - Non-standard labels such as `R-` (refactor), `I-` (informational), or `S-` (suggestion) will be considered non-critical and are therefore discouraged.


### PR DESCRIPTION
- Remove references to org repo
- Clean up language re: 
   - "contests" -> competitions
   - "bugs" -> vulnerabilities or submissions
   - imprecise use of "findings/submissions"
- Clarify that not all competitions include a firm 4% QA pool
- Move deprecated info re: Z pools/Dark Horse pools to historical info page
- condense all info re: Analyses into historical info page
- sentence case for section headings
- restructure judging criteria page to group all info re: duplicates together